### PR TITLE
Add the build-info plugin

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -25,6 +25,8 @@ const packageJson = require(paths.appPackageJson);
 const ModuleNotFoundPlugin = require('react-dev-utils/ModuleNotFoundPlugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin-alt');
 const typescriptFormatter = require('react-dev-utils/typescriptFormatter');
+const BuildInfoPlugin = require('@infosight/build-info-webpack-plugin');
+
 // @remove-on-eject-begin
 const getCacheIdentifier = require('react-dev-utils/getCacheIdentifier');
 // @remove-on-eject-end
@@ -440,6 +442,8 @@ module.exports = {
       fileName: 'asset-manifest.json',
       publicPath: publicPath,
     }),
+    // Generate a build-info.json file that contains dependency summaries, git info and a timestamp
+    new BuildInfoPlugin(),
     // This allows the shell to auto-reload and find
     // port: '*' enables the plugin to find an available port for livereload
     new LiveReloadPlugin({

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -26,6 +26,8 @@ const getClientEnvironment = require('./env');
 const ModuleNotFoundPlugin = require('react-dev-utils/ModuleNotFoundPlugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin-alt');
 const typescriptFormatter = require('react-dev-utils/typescriptFormatter');
+const BuildInfoPlugin = require('@infosight/build-info-webpack-plugin');
+
 // @remove-on-eject-begin
 const getCacheIdentifier = require('react-dev-utils/getCacheIdentifier');
 // @remove-on-eject-end
@@ -517,6 +519,8 @@ module.exports = {
       fileName: 'asset-manifest.json',
       publicPath: publicPath,
     }),
+    // Generate a build-info.json file that contains dependency summaries, git info and a timestamp
+    new BuildInfoPlugin(),
     // Moment.js is an extremely popular library that bundles large locale files
     // by default due to how Webpack interprets its code. This is a practical
     // solution that requires the user to opt into importing specific locales.

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -25,7 +25,7 @@
   "types": "./lib/react-app.d.ts",
   "dependencies": {
     "@babel/core": "7.1.0",
-    "@infosight/build-info-webpack-plugin": "1.0.0",
+    "@infosight/build-info-webpack-plugin": "^1.0.1",
     "@svgr/webpack": "2.4.1",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "9.0.0",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -25,6 +25,7 @@
   "types": "./lib/react-app.d.ts",
   "dependencies": {
     "@babel/core": "7.1.0",
+    "@infosight/build-info-webpack-plugin": "1.0.0",
     "@svgr/webpack": "2.4.1",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "9.0.0",


### PR DESCRIPTION
This is a new plugin I published this morning. This is now the result when a microapp is deployed.

```
{
  "path": "https://s3.amazonaws.com/infosight-hpe-com/frontend/microapps/prostack/dev/181105130930",
  "entryVersion": "2",
  "build": {
    "timestamp": "2018-11-05T18:03:13.584Z",
    "git": {
      "sha": "1f8e936c4a61ecda68287ac65c0530b5315ec166",
      "branch": "master",
      "committerDate": "2018-11-01T15:02:41.000Z"
    },
    "name": "@infosight/portal-prostack-frontend",
    "dependencies": {
      "@infosight/microapp-scripts": {
        "requested": "^2.3.0"
      },
      "react-redux": {
        "resolved": "http://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
        "requested": "5.0.7"
      },
      "highcharts-more": {
        "resolved": "https://registry.npmjs.org/highcharts-more/-/highcharts-more-0.1.7.tgz",
        "requested": "^0.1.2"
      },
      "react-router-dom": {
        "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.2.2.tgz",
        "requested": "4.2.2"
      },
      "urijs": {
        "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
        "requested": "1.19.1"
      },
      "styled-components": {
        "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-3.3.3.tgz",
        "requested": "3.3.3"
      },
      "axios": {
        "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.0.tgz",
        "requested": "0.17.0"
      },
      "highcharts-pattern-fill": {
        "resolved": "https://registry.npmjs.org/highcharts-pattern-fill/-/highcharts-pattern-fill-3.0.3.tgz",
        "requested": "^3.0.0"
      },
      "elmer": {
        "resolved": "git+https://github.hpe.com/infosight/elmer#953d81d77b00b6cf1ba4cb1ce6e5a801d9d6e5ca",
        "requested": "git+https://github.hpe.com/infosight/elmer"
      },
      "numeral": {
        "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
        "requested": "2.0.6"
      },
      "redux-thunk": {
        "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
        "requested": "2.3.0"
      },
      "redux-devtools-extension": {
        "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.5.tgz",
        "requested": "2.13.5"
      },
      "object-hash": {
        "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.1.5.tgz",
        "requested": "1.1.5"
      },
      "react": {
        "resolved": "https://registry.npmjs.org/react/-/react-16.5.2.tgz",
        "requested": "^16.5.2"
      },
      "moment": {
        "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
        "requested": "2.22.2"
      },
      "@infosight/shell-api": {
        "resolved": "git+https://github.hpe.com/infosight/shell-api#20c4b3b3f4336a81389c6665441632b1a90a3955",
        "requested": "git+https://github.hpe.com/infosight/shell-api"
      },
      "underscore": {
        "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
        "requested": "1.9.1"
      },
      "react-autobind": {
        "resolved": "https://registry.npmjs.org/react-autobind/-/react-autobind-1.0.6.tgz",
        "requested": "1.0.6"
      },
      "react-dom": {
        "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.5.2.tgz",
        "requested": "^16.5.2"
      },
      "react-router": {
        "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.2.0.tgz",
        "requested": "4.2.0"
      },
      "classnames": {
        "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
        "requested": "2.2.5"
      },
      "moment-timezone": {
        "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.20.tgz",
        "requested": "0.5.20"
      },
      "prop-types": {
        "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.8.tgz",
        "requested": "15.5.8"
      },
      "redux": {
        "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
        "requested": "4.0.1"
      },
      "highcharts": {
        "resolved": "http://registry.npmjs.org/highcharts/-/highcharts-4.2.6.tgz",
        "requested": "4.2.6"
      },
      "history": {
        "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
        "requested": "4.7.2"
      }
    }
  },
  "manifest": {
    "precache-manifest.a51d239d5d2e9a4efdf91ff47a184321.js": "/precache-manifest.a51d239d5d2e9a4efdf91ff47a184321.js",
    "static/js/4.6348ab6c.chunk.js": "/static/js/4.6348ab6c.chunk.js",
    "build-info.json": "/build-info.json",
    "static/js/0.16dbf0bc.chunk.js": "/static/js/0.16dbf0bc.chunk.js",
    "static/css/3.6b9bf7e8.chunk.css.map": "/static/css/3.6b9bf7e8.chunk.css.map",
    "main.js": "/static/js/main.f6123794.js",
    "static/js/3.2cb8eaea.chunk.js": "/static/js/3.2cb8eaea.chunk.js",
    "static/js/3.2cb8eaea.chunk.js.map": "/static/js/3.2cb8eaea.chunk.js.map",
    "static/js/2.dc02960b.chunk.js.map": "/static/js/2.dc02960b.chunk.js.map",
    "service-worker.js": "/service-worker.js",
    "static/js/2.dc02960b.chunk.js": "/static/js/2.dc02960b.chunk.js",
    "static/css/3.6b9bf7e8.chunk.css": "/static/css/3.6b9bf7e8.chunk.css",
    "main.js.map": "/static/js/main.f6123794.js.map",
    "static/js/0.16dbf0bc.chunk.js.map": "/static/js/0.16dbf0bc.chunk.js.map",
    "static/js/4.6348ab6c.chunk.js.map": "/static/js/4.6348ab6c.chunk.js.map"
  }
}
```