### PR TITLE
Support Grommet2@latest alongside Grommet2@beta.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 `npx lerna bootstrap`
 
-# Developing
+# Developing for HPE InfoSight Microapps
 
 Everything you need to edit is probably in [react-scripts](packages/react-scripts). You can test locally
 with `npm link`.
@@ -14,8 +14,20 @@ cd packages/react-scripts
 npm link
 ```
 
-If you have problems, delete [node_modules](packages/react-scripts/node_modules) and run `npx lerna bootstrap` again.
-You shouldn't have to run `npm install` or `yarn`. Basically, always use lerna or expect problems.
+If you have problems, run `npx lerna clean && npx lerna bootstrap` again.
+Do not run `npm install` or `yarn`. Always use lerna or expect problems.
+
+# Publishing
+
+Since this repo is on public GitHub, you need to publish packages manually.
+
+1. Bump the version in the packages `package.json` file. Do not use `lerna version`
+1. Very likely, if you're editing this repo, you have push privileges on our private npm registry. If not, a maintainer should probably handle the publishing.
+1. Publish using `npm publish`.
+   - If you need to publish a pre-release version, be sure to use appropriate versioning and set a tag. Otherwise your beta becomes somebody's prod version
+     if they aren't commiting the `package-lock.json` file in thier microapp.
+   - `npm publish --tag prerelease`
+   - If you forget, use [`npm dist-tag`](https://docs.npmjs.com/cli/dist-tag) to move the `latest` tag and set `prerelease`
 
 ## Everything below this point is from create-react-app
 

--- a/packages/react-scripts/config/libraryCompatibility.js
+++ b/packages/react-scripts/config/libraryCompatibility.js
@@ -1,0 +1,55 @@
+'use strict';
+
+/**
+ * Add support for Grommet2@latest + styled-components@5 while retaining backward-compatibility with Grommet@2.beta5 + styled-compoments@3
+ * The microapp is expected to use an environment variable to specify the compatibility mode:
+ *
+ *      `REACT_APP_STYLED_COMPONENTS_COMPATIBILITY_MODE=grommet2.beta5` supports Grommet2@beta.5 by configuring an alias in the
+ *          bundle that points to the global instance of styled-components v3.x.x.
+ *          This is the default mode if this env var is not set.
+ *
+ *      `REACT_APP_STYLED_COMPONENTS_COMPATIBILITY_MODE=grommet2` supports Grommet2 by configuring an alias in the bundle that
+ *          points to the global instance of styled-components most compatible with v5.x.x (at this time 6.x.x is anticipated to be backward-compatible)
+ *
+ *      `REACT_APP_STYLED_COMPONENTS_COMPATIBILITY_MODE=none` is a hint not to use the global instances and instead include styled-components in the bundle.
+ *          In this case, the microapp must also set [`REACT_APP_SC_ATTR`](https://styled-components.com/docs/advanced#avoiding-conflicts-with-thirdparty-styles-and-scripts)
+ */
+module.exports.getWebpackExternalsForStyledComponents = () => {
+  const externals = {};
+  let styledComponentsVersion;
+  const scCompatibilityMode =
+    process.env.REACT_APP_STYLED_COMPONENTS_COMPATIBILITY_MODE ||
+    process.env.STYLED_COMPONENTS_COMPATIBILITY_MODE;
+  switch (scCompatibilityMode) {
+    case 'grommet2.beta5':
+      styledComponentsVersion = '3xx';
+      break;
+    case 'grommet2':
+      styledComponentsVersion = '5xx';
+      break;
+    case 'none':
+      styledComponentsVersion = 'bundled';
+      break;
+    default:
+      break;
+  }
+
+  // This should rarely be used, but it's a safe way to breakout whenever avoiding the global instance is preferable
+  // This will be an undocumented feature.
+  if (styledComponentsVersion === 'bundled') {
+    console.warn(
+      `Including styled-components in your app's bundle. Be sure to set "process.env.REACT_APP_SC_ATTR" to a value unique to your app, such as "data-styled-vmware" if your microapp's ID is "vmware". See https://styled-components.com/docs/advanced#avoiding-conflicts-with-thirdparty-styles-and-scripts for details.`
+    );
+  } else if (styledComponentsVersion) {
+    // This is the core use case: setting to a specific global instance of SC
+    externals['styled-components'] = `styled_${styledComponentsVersion}`;
+  } else {
+    // Backward-compatibility - the shell aliases window.styled_3xx as window.styled.
+    console.warn(
+      `Defaulting to legacy compatibility mode for grommet2@beta.5 with styled-components@3.x.x`
+    );
+    externals['styled-components'] = 'styled';
+  }
+
+  return externals;
+};

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -298,11 +298,13 @@ module.exports = function(webpackEnv) {
     },
     // All microapps should share the same version of a very limited subset of global dependencies.
     // Typically, these should be limited to dependencies that cannot be scoped and cannot have multiple coexisting versions.
-    externals: {
-      react: 'React',
-      'react-dom': 'ReactDOM',
-      ...getWebpackExternalsForStyledComponents(),
-    },
+    externals: [
+      {
+        react: 'React',
+        'react-dom': 'ReactDOM',
+      },
+      getWebpackExternalsForStyledComponents(),
+    ],
     resolve: {
       // This allows you to set a fallback for where Webpack should look for modules.
       // We placed these paths second because we want `node_modules` to "win"

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -300,15 +300,17 @@ module.exports = function(webpackEnv) {
     // Typically, these should be limited to dependencies that cannot be scoped and cannot have multiple coexisting versions.
     externals: (function(externals) {
       // Backward-compatible support for Grommet@2.beta5 + styled-compoments@3
-      // Microapps that have not upgraded will still use the global `window.styled`
-      // Microapps that have upgraded should explicitly pass a value, currently '3'|'5' are supported by the shell.
-      // If a value is not passed, the bundle will include styled-components, which means that process.env.SC_ATTR is required.
-      // TODO enforce the previous
+      // Microapps that have not upgraded to the latest version of @infosight/microapp-scripts will still use the global `window.styled`
+      // Microapps that have upgraded should explicitly pass a value; currently '3xx'|'5xx' are supported by the shell.
+      //    However, this is forgiving and defaults back to 3xx
+      // If a value "bundled" is passed, the bundle will include styled-components, which means that process.env.SC_ATTR is required.
       const styledComponentsVersion =
         process.env.REACT_APP_STYLED_COMPONENTS_VERSION ||
-        process.env.STYLED_COMPONENTS_VERSION;
-      if (styledComponentsVersion && styledComponentsVersion !== 'local') {
-        externals['styled-components'] = `styled_${styledComponentsVersion}xx`;
+        process.env.STYLED_COMPONENTS_VERSION ||
+        '3xx';
+
+      if (styledComponentsVersion && styledComponentsVersion !== 'bundled') {
+        externals['styled-components'] = `styled_${styledComponentsVersion}`;
       }
       return externals;
     })({

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -37,7 +37,9 @@ const eslint = require('eslint');
 const getCacheIdentifier = require('react-dev-utils/getCacheIdentifier');
 // @remove-on-eject-end
 const postcssNormalize = require('postcss-normalize');
-
+const {
+  getWebpackExternalsForStyledComponents,
+} = require('./libraryCompatibility');
 const appPackageJson = require(paths.appPackageJson);
 
 // Source maps are resource heavy and can cause out of memory issue for large source files.
@@ -298,25 +300,11 @@ module.exports = function(webpackEnv) {
     },
     // All microapps should share the same version of a very limited subset of global dependencies.
     // Typically, these should be limited to dependencies that cannot be scoped and cannot have multiple coexisting versions.
-    externals: (function(externals) {
-      // Backward-compatible support for Grommet@2.beta5 + styled-compoments@3
-      // Microapps that have not upgraded to the latest version of @infosight/microapp-scripts will still use the global `window.styled`
-      // Microapps that have upgraded should explicitly pass a value; currently '3xx'|'5xx' are supported by the shell.
-      //    However, this is forgiving and defaults back to 3xx
-      // If a value "bundled" is passed, the bundle will include styled-components, which means that process.env.SC_ATTR is required.
-      const styledComponentsVersion =
-        process.env.REACT_APP_STYLED_COMPONENTS_VERSION ||
-        process.env.STYLED_COMPONENTS_VERSION ||
-        '3xx';
-
-      if (styledComponentsVersion && styledComponentsVersion !== 'bundled') {
-        externals['styled-components'] = `styled_${styledComponentsVersion}`;
-      }
-      return externals;
-    })({
+    externals: {
       react: 'React',
       'react-dom': 'ReactDOM',
-    }),
+      ...getWebpackExternalsForStyledComponents(),
+    },
     resolve: {
       // This allows you to set a fallback for where Webpack should look for modules.
       // We placed these paths second because we want `node_modules` to "win"

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -190,8 +190,6 @@ module.exports = function(webpackEnv) {
       // We inferred the "public path" (such as / or /my-project) from homepage.
       // We use "/" in development.
       publicPath: publicPath,
-      // Fix WebWorkers: https://github.com/webpack/webpack/issues/6642
-      globalObject: 'self',
       // Point sourcemap entries to original disk location (format as URL on Windows)
       devtoolModuleFilenameTemplate: isEnvProduction
         ? info =>

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -298,11 +298,23 @@ module.exports = function(webpackEnv) {
     },
     // All microapps should share the same version of a very limited subset of global dependencies.
     // Typically, these should be limited to dependencies that cannot be scoped and cannot have multiple coexisting versions.
-    externals: {
+    externals: (function(externals) {
+      // Backward-compatible support for Grommet@2.beta5 + styled-compoments@3
+      // Microapps that have not upgraded will still use the global `window.styled`
+      // Microapps that have upgraded should explicitly pass a value, currently '3'|'5' are supported by the shell.
+      // If a value is not passed, the bundle will include styled-components, which means that process.env.SC_ATTR is required.
+      // TODO enforce the previous
+      const styledComponentsVersion =
+        process.env.REACT_APP_STYLED_COMPONENTS_VERSION ||
+        process.env.STYLED_COMPONENTS_VERSION;
+      if (styledComponentsVersion && styledComponentsVersion !== 'local') {
+        externals['styled-components'] = `styled_${styledComponentsVersion}xx`;
+      }
+      return externals;
+    })({
       react: 'React',
       'react-dom': 'ReactDOM',
-      'styled-components': 'styled',
-    },
+    }),
     resolve: {
       // This allows you to set a fallback for where Webpack should look for modules.
       // We placed these paths second because we want `node_modules` to "win"

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infosight/microapp-scripts",
-  "version": "3.1.0-rc2",
+  "version": "3.1.0",
   "description": "Configuration and scripts for Create React InfoSight Microapp.",
   "repository": "goodmorninggoaway/create-react-infosight-microapp",
   "license": "MIT",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infosight/microapp-scripts",
-  "version": "3.0.0",
+  "version": "3.1.0-rc1",
   "description": "Configuration and scripts for Create React InfoSight Microapp.",
   "repository": "goodmorninggoaway/create-react-infosight-microapp",
   "license": "MIT",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infosight/microapp-scripts",
-  "version": "3.1.0-rc1",
+  "version": "3.1.0-rc2",
   "description": "Configuration and scripts for Create React InfoSight Microapp.",
   "repository": "goodmorninggoaway/create-react-infosight-microapp",
   "license": "MIT",


### PR DESCRIPTION
Add support for Grommet2@latest + styled-components@5 while retaining backward-compatibility with Grommet@2.beta5 + styled-compoments@3

The microapp is expected to use an environment variable `REACT_APP_STYLED_COMPONENTS_COMPATIBILITY_MODE` to specify the compatibility mode:
* `grommet2.beta5` **default** supports Grommet2@beta.5 by configuring an alias in the bundle that points to the global instance of styled-components v3.x.x. 
* `grommet2` supports Grommet2@latest by configuring an alias in the bundle that points to the global instance of styled-components most compatible with v5.x.x (at this time 6.x.x is anticipated to be backward-compatible)
* `none` is a hint not to use the global instances and instead include styled-components in the bundle. In this case, the microapp must also set [`REACT_APP_SC_ATTR`](https://styled-components.com/docs/advanced#avoiding-conflicts-with-thirdparty-styles-and-scripts). This should rarely be used.

This allows us to use both versions of grommet2 in the portal. It may also be possible for a microapp to use both versions simultaneously, but that is untested and will not be our recommendation. The ~~recommendation~~ instruction will be to install grommet into the microapp, directly use it in all places where they were imported through elmer. ~~A future version of elmer should remove those grommet re-exports.~~ Elmer will remove the re-exports.

~~Additionally, any usage of elmer components that use grommet components will need to be updated. I'm currently thinking of how that should be implemented:~~
~~1. Publish a new version of elmer that depends on grommet2@latest. This is a breaking change but easier.~~
~~1. Start a new monorepo that uses grommet as a peer dependency. This is a little more work, but my preferred approach so we can independently version and deploy components like Modal and FlashNotification. It's not quite elmer2.~~
~~1. Migrate the higher-level components to individual repos (sort of like a very basic version of the [bit philosophy](https://docs.bit.dev/docs/quick-start) philosophy).~~

A new version of Elmer upgraded to grommet 2 will be published. 

This is published as a prerelease versions for further testing starting with `3.1.0-rc1`.
